### PR TITLE
ci: set timeout in golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,3 +15,5 @@ jobs:
         uses: golangci/golangci-lint-action@v2.5.1
         with:
           version: v1.29
+          args: --timeout 5m
+


### PR DESCRIPTION
Increased from 1m to 5m

Signed-off-by: roee88 <roee88@gmail.com>