### PR TITLE
fix: generation when using gkv flag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,3 +23,11 @@ jobs:
           go mod tidy
           git checkout go.sum
           git diff --exit-code
+      - name: Run on example (gkv)
+        run: |
+          go run main.go example/spec.yaml -g project.io/v1alpha1/Example -o example/output/output.yaml
+      - name: Check that there are no source code changes
+        run: |
+          go mod tidy
+          git checkout go.sum
+          git diff --exit-code

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -27,7 +27,11 @@ func (g *Generator) Generate(crd *apiextensions.CustomResourceDefinition, spec o
 	// A workaround because ValidateCRD requires at least one stored version in the status.
 	// Otherwise the following error is raised:
 	// status.storedVersions: Invalid value: []string{}: must have at least one stored version
-	crd.Status.StoredVersions = []string{crd.Spec.Version}
+	for _, version := range crd.Spec.Versions {
+		if version.Storage {
+			crd.Status.StoredVersions = append(crd.Status.StoredVersions, version.Name)
+		}
+	}
 
 	if err := ValidateCRD(crd); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR fixes an error thrown when using the `gkv` flag:

```
[status.storedVersions: Invalid value: apiextensions.CustomResourceDefinitionVersion{Name:"v1alpha1", Served:true, Storage:true, Deprecated:false, DeprecationWarning:(*string)(nil), Schema:(*apiextensions.CustomResourceValidation)(nil), Subresources:(*apiextensions.CustomResourceSubresources)(nil), AdditionalPrinterColumns:[]apiextensions.CustomResourceColumnDefinition(nil)}: must have the storage version v1alpha1, status.storedVersions[0]: Invalid value: "": must appear in spec.versions]
```